### PR TITLE
Custom backend

### DIFF
--- a/lib/customizer.dart
+++ b/lib/customizer.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -23,62 +24,109 @@ class _CustomizerPageState extends State<CustomizerPage> {
   Widget build(BuildContext context) {
 
     //build globals
+    final user = FirebaseAuth.instance.currentUser;
     
     //reference to the cuisine collection
-    CollectionReference cuisine = FirebaseFirestore.instance.collection("cuisine");
+    //CollectionReference cuisine = FirebaseFirestore.instance.collection("cuisine");
+    //get the document reference for the user currently logged in
+    
+    //TODO: Add check for whether a valid user is signed in before changing preferences
+    //TODO: When user logs out, clear preferences
+    var userPref = FirebaseFirestore.instance.collection('users').doc(user?.uid);
 
     return Scaffold(
       appBar: JustEatItAppBar.create(context),
       //body of list view
-      body: CustomScrollView(
-        slivers: <Widget>[
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, int index) {
-                return Container(
-                  alignment: Alignment.center,
-                  //color: const Color.fromARGB(255, 18, 119, 21),
-                  height: 150,
-                  child: TextButton(
-                    style: TextButton.styleFrom(
-                      textStyle: const TextStyle(fontSize: 30),
+      body: Center(
+        child: ListView(
+          padding: const EdgeInsets.all(8),
+          children: <Widget>[
+            //----------CHINESE----------
+            Container(
+              alignment: Alignment.center,
+              height: 150,
+              child: TextButton(
+                onPressed: () {
+                  //set user preference
+                  userPref.set({'preferences': 'chinese'});
+                  Navigator.popAndPushNamed(context, '/restaurants');
+                },
+                style: TextButton.styleFrom(
+                  textStyle: const TextStyle(
+                    fontSize: 30,
+                    color:Color.fromARGB(255, 18, 119, 21), 
                     ),
-                    //when pressed, send data and move to reccomendation page
-                    onPressed: () {
-                      //does not update suggestion pool at the moment
-                      Navigator.popAndPushNamed(context, '/restaurants');
-                    },
-                    child: FutureBuilder<DocumentSnapshot>(
-                      future: cuisine.doc(index.toString()).get(),
-                      builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
-                        if(snapshot.hasError){
-                          return const Text("Something went wrong");
-                        }
-
-                        if(snapshot.hasData && !snapshot.data!.exists){
-                          return const Text("Document does not exist",);
-                        }
-
-                        if(snapshot.connectionState == ConnectionState.done) {
-                          Map<String, dynamic> data = snapshot.data!.data() as Map<String, dynamic>;
-                          return Text(
-                            "${data["name"]}", 
-                            style: const TextStyle(
-                              fontSize: 40,
-                              color: Color.fromARGB(255, 18, 119, 21),
-                              ),
-                          );
-                        }
-                        return const Text("loading"); //appears while firestore is retrieving data
-                      },
-                    ), 
-                  ),
-                );
-              },
-              childCount: 4, //adjusts the current length of the list
-              )
-            )
-        ],
+                ),
+                child: const Text(
+                  "Chinese", 
+                ),
+              ),
+            ),
+            //----------JAPANESE----------
+            Container(
+              alignment: Alignment.center,
+              height: 150,
+              child: TextButton(
+                onPressed: () {
+                  //set user preference
+                  userPref.set({'preferences': 'japanese'});
+                  Navigator.popAndPushNamed(context, '/restaurants');
+                },
+                style: TextButton.styleFrom(
+                  textStyle: const TextStyle(
+                    fontSize: 30,
+                    color:Color.fromARGB(255, 18, 119, 21), 
+                    ),
+                ),
+                child: const Text(
+                  "Japanese", 
+                ),
+              ),
+            ),
+            //----------MEXICAN----------
+            Container(
+              alignment: Alignment.center,
+              height: 150,
+              child: TextButton(
+                onPressed: () {
+                  //set user preference
+                  userPref.set({'preferences': 'mexican'});
+                  Navigator.popAndPushNamed(context, '/restaurants');
+                },
+                style: TextButton.styleFrom(
+                  textStyle: const TextStyle(
+                    fontSize: 30,
+                    color:Color.fromARGB(255, 18, 119, 21), 
+                    ),
+                ),
+                child: const Text(
+                  "Mexican", 
+                ),
+              ),
+            ),
+            //----------MEDITERANIAN----------
+            Container(
+              alignment: Alignment.center,
+              height: 150,
+              child: TextButton(
+                onPressed: () {
+                  //set user preference
+                  userPref.set({'preferences': 'mediteranian'});
+                  Navigator.popAndPushNamed(context, '/restaurants');
+                },
+                style: TextButton.styleFrom(
+                  textStyle: const TextStyle(
+                    fontSize: 30,
+                    color:Color.fromARGB(255, 18, 119, 21), 
+                    ),
+                ),
+                child: const Text(
+                  "Mediteranian", 
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/signup.dart
+++ b/lib/signup.dart
@@ -109,7 +109,7 @@ class SignupPageState extends State<SignupPage> {
                           password: passwordController.text,
                         ).then((value) {
                           //add user to users collection with email field empty preferences field
-                          FirebaseFirestore.instance.collection('users').doc(value.user?.uid).set({'email': value.user?.email,'preferences': "None"});
+                          FirebaseFirestore.instance.collection('users').doc(value.user?.uid).set({'email': value.user?.email,'preferences': ''});
                         });
                         Navigator.popAndPushNamed(context, '/preferences');
                       } on FirebaseAuthException catch (e) {

--- a/lib/signup.dart
+++ b/lib/signup.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
@@ -106,7 +107,10 @@ class SignupPageState extends State<SignupPage> {
                         await FirebaseAuth.instance.createUserWithEmailAndPassword(
                           email: emailController.text,
                           password: passwordController.text,
-                        );
+                        ).then((value) {
+                          //add user to users collection with email field empty preferences field
+                          FirebaseFirestore.instance.collection('users').doc(value.user?.uid).set({'email': value.user?.email,'preferences': "None"});
+                        });
                         Navigator.popAndPushNamed(context, '/preferences');
                       } on FirebaseAuthException catch (e) {
                         if (e.code == 'email-already-in-use') {


### PR DESCRIPTION
I have added a 'users' collection that can store the data of individual users once they have signed up. When a user has created an account for the first time, they are assigned a user id which can be stored in the firestore database as the document id in the 'users' collection. The user id should stay consistent each time a user logs in. Using this new collection, I have added part of the customization back end. In the customization menu, a cuisine option can be selected and it will be sent to the users profile under the 'preferences' field. The code for the button list is not the most efficient but it works. If we have time, we can make it more streamline. I still need to implement the ability to have these preferences affect the recommendation, but that shouldn't be too difficult. We will probably have to create the ability to clear the preferences as well. 

https://user-images.githubusercontent.com/68746158/163699961-3b4593c4-b96f-4790-a8e0-8529c7bd5d3c.mp4


