### PR TITLE
Updated Customization Page and Preference Storage

### DIFF
--- a/lib/customizer.dart
+++ b/lib/customizer.dart
@@ -44,26 +44,32 @@ class _CustomizerPageState extends State<CustomizerPage> {
           //==========SELECTION VIEW==========
           Expanded(
             child: ListView(
-              padding: const EdgeInsets.all(8),
+              padding: const EdgeInsets.all(20),
               children: <Widget>[
-                //----------CHINESE----------
-                _buildSelection("Chinese", userPref, context),
-                //----------JAPANESE----------
-                _buildSelection("Japanese", userPref, context),
-                //----------MEXICAN----------
-                _buildSelection("Mexican", userPref, context),
-                //----------MEDITERANIAN----------
-                _buildSelection("Mediteranian", userPref, context),
+                 //----------AMERICAN----------
+                _buildSelection("American", userPref, context),
+                const Divider(),
+                 //----------BEVERAGES----------
+                _buildSelection("Beverages", userPref, context),
+                const Divider(),
                 //----------BREAKFAST----------
                 _buildSelection("Breakfast", userPref, context),
-                //----------BEVERAGES----------
-                _buildSelection("Beverages", userPref, context),
-                //----------AMERICAN----------
-                _buildSelection("American", userPref, context),
+                const Divider(),
+                //----------CHINESE----------
+                _buildSelection("Chinese", userPref, context),
+                const Divider(),
                 //----------HEALTH----------
                 _buildSelection("Health", userPref, context),
-                //----------RESET PREFERENCES----------
-                _clearPreferences(userPref, context),
+                const Divider(),
+                //----------JAPANESE----------
+                _buildSelection("Japanese", userPref, context),
+                const Divider(),
+                 //----------MEDITERANIAN----------
+                _buildSelection("Mediteranian", userPref, context),
+                const Divider(),  
+                //----------MEXICAN----------
+                _buildSelection("Mexican", userPref, context),
+                const Divider(),
               ],
             ),
           ),
@@ -77,6 +83,12 @@ class _CustomizerPageState extends State<CustomizerPage> {
                 child: const Text("No Preferences Selected"),
               ),
           ),
+          //----------RESET PREFERENCES----------
+          Container(
+            alignment: Alignment.bottomRight,
+            padding: const EdgeInsets.all(20),
+            child: _clearPreferences(userPref, context),
+          )
         ], //end of Row children
       ),
     );
@@ -98,7 +110,7 @@ class _CustomizerPageState extends State<CustomizerPage> {
         semanticLabel: alreadySaved ? 'Remove from Selected' : 'Select',
       ),
       title: Text(
-        name,
+        name, //name of restaurant
         style: TextStyle(
           color: Colors.green.shade800,
           fontSize: 30,
@@ -109,12 +121,8 @@ class _CustomizerPageState extends State<CustomizerPage> {
         setState(() {
           if(alreadySaved){
             _saved.remove(name);
-            //add code here to update the users preference list in data base based on current _saved array
-            //userPref.update({'preferences': _saved});
           } else{
             _saved.add(name);
-            //add code here to update the users preference list in data base based on current _saved array
-            //userPref.update({'preferences': _saved});
           }
           userPref.update({'preferences': _saved});
         });
@@ -127,6 +135,7 @@ class _CustomizerPageState extends State<CustomizerPage> {
 
     //return a buildable list that displays what has been favorited by the user
     return ListView.separated(
+      padding: const EdgeInsets.all(15),
       separatorBuilder: (context, index) => Divider(color: Colors.green.shade900),
       itemCount: _saved.length, //number of tiles equals length of preferences list
       itemBuilder: (context, int index) {
@@ -140,35 +149,20 @@ class _CustomizerPageState extends State<CustomizerPage> {
   //Clear preferences
   Widget _clearPreferences(DocumentReference<Map<String, dynamic>> userPref, BuildContext context){
 
-    //maybe turn this into a floating button
-
-    return Container(
-      alignment: Alignment.center,
-      height: 200,
-      child: ElevatedButton(
-        onPressed: () {
-          setState(() {
-            //clear _saved
-            removeAll();
-            userPref.update({'preferences': []}); //set preferences to be an empty array
-          });
-          //clear _saved
+    return FloatingActionButton(
+      child: const Icon(
+        Icons.refresh,
+      ),
+      onPressed: () {
+        setState(() {
           removeAll();
           userPref.update({'preferences': []}); //set preferences to be an empty array
-        },
-        style: ElevatedButton.styleFrom(
-          textStyle: const TextStyle(
-            fontSize: 30,
-            color:Color.fromARGB(255, 18, 119, 21), 
-            ),
-        ),
-        child: const Text(
-          "Reset Preferences",
-        ),
-      ),
+        });
+      }
     );
   }
 
+  //helper method that removes all 
   void removeAll(){
     while(_saved.isNotEmpty){
       _saved.removeAt(0); //remove the first index of the list until its empty

--- a/lib/customizer.dart
+++ b/lib/customizer.dart
@@ -33,6 +33,7 @@ class _CustomizerPageState extends State<CustomizerPage> {
     //TODO: Add check for whether a valid user is signed in before changing preferences
     //TODO: When user logs out, clear preferences
     var userPref = FirebaseFirestore.instance.collection('users').doc(user?.uid);
+    //var restNameList = ['chinese', 'japanese', 'mexican', 'mediteranian'];
 
     return Scaffold(
       appBar: JustEatItAppBar.create(context),
@@ -48,7 +49,9 @@ class _CustomizerPageState extends State<CustomizerPage> {
               child: TextButton(
                 onPressed: () {
                   //set user preference
-                  userPref.set({'preferences': 'chinese'});
+                  var chin = ['chinese']; //needs to be of  List<String> type
+                  userPref.update({'preferences': FieldValue.arrayUnion(chin)});
+                  //userPref.set({'preferences': 'chinese'});
                   Navigator.popAndPushNamed(context, '/restaurants');
                 },
                 style: TextButton.styleFrom(
@@ -69,7 +72,10 @@ class _CustomizerPageState extends State<CustomizerPage> {
               child: TextButton(
                 onPressed: () {
                   //set user preference
-                  userPref.set({'preferences': 'japanese'});
+                  var jap = ['japanese'];
+                  //userPref.
+                  userPref.update({'preferences': FieldValue.arrayUnion(jap)});
+                  //userPref.set({'preferences': 'japanese'});
                   Navigator.popAndPushNamed(context, '/restaurants');
                 },
                 style: TextButton.styleFrom(
@@ -90,7 +96,8 @@ class _CustomizerPageState extends State<CustomizerPage> {
               child: TextButton(
                 onPressed: () {
                   //set user preference
-                  userPref.set({'preferences': 'mexican'});
+                  var mex = ['mexican'];
+                  userPref.update({'preferences': FieldValue.arrayUnion(mex)});
                   Navigator.popAndPushNamed(context, '/restaurants');
                 },
                 style: TextButton.styleFrom(
@@ -111,7 +118,8 @@ class _CustomizerPageState extends State<CustomizerPage> {
               child: TextButton(
                 onPressed: () {
                   //set user preference
-                  userPref.set({'preferences': 'mediteranian'});
+                  var med = ['mediteranian'];
+                  userPref.update({'preferences': FieldValue.arrayUnion(med)});
                   Navigator.popAndPushNamed(context, '/restaurants');
                 },
                 style: TextButton.styleFrom(

--- a/lib/signup.dart
+++ b/lib/signup.dart
@@ -108,10 +108,10 @@ class SignupPageState extends State<SignupPage> {
                           email: emailController.text,
                           password: passwordController.text,
                         ).then((value) {
-                          //add user to users collection with email field empty preferences field
-                          FirebaseFirestore.instance.collection('users').doc(value.user?.uid).set({'email': value.user?.email,'preferences': ''});
+                          //add user to users collection with email field empty preferences array
+                          FirebaseFirestore.instance.collection('users').doc(value.user?.uid).set({'email': value.user?.email,'preferences': []});
                         });
-                        Navigator.popAndPushNamed(context, '/preferences');
+                        Navigator.popAndPushNamed(context, '/pref_nav'); //direct to customization menu
                       } on FirebaseAuthException catch (e) {
                         if (e.code == 'email-already-in-use') {
                           setState(() => formError = 'An account already exists for ${emailController.text}. Please try again with a different email.');


### PR DESCRIPTION
This update isn't pretty and I still have some things to work out but I wanted to get a solid update out there. I updated the user collection to store a preferences array instead of just a string. I've changed the selection process from being a list of buttons to an interactive tile. When a user selects a preference, it will show up on the right hand side of the page. The goal is to have a larger running list of customization choices so having the right hand side makes more sense. The current ListView widget is a little finnicky when used in a Column/Row widget so I plan on looking into other scrollables like CustomScrollView to see if I can get a scrolling list that flows better. I also made the reset preferences button into a FloatingActionButton. Let me know if yall have any other design ideas! I (obviously) still need to update it to look better but I also want to add titles for each scroll list.

https://user-images.githubusercontent.com/68746158/164949533-f884b537-98bb-48a9-a8b8-0d410e775f94.mp4