### PR TITLE
Fixed alignment issue between weekday and hours indexing in database

### DIFF
--- a/lib/restaurants.dart
+++ b/lib/restaurants.dart
@@ -152,7 +152,7 @@ class _RestaurantsPageState extends State<RestaurantsPage> {
                     ]),
                     Row(children: [
                       const Icon(Icons.access_time),
-                      Text(recommended!.hours[DateTime.now().weekday]),
+                      Text(recommended!.hours[DateTime.now().weekday-1]), //subtract 1 to align with database array
                     ]),
                   ],
                 ),


### PR DESCRIPTION
When doing a run through after the most recent update, I came across a strange error on the recommendation page after the video finished playing...
![Rec_error](https://user-images.githubusercontent.com/68746158/164991550-69c32f99-2a90-466a-ab31-042c4f0cb742.PNG)

Apparently the DateTime class starts the week on Mondays and indexing at 1. Since the databases index starts at 0, whenever its sunday (whos index is 7 in flutter but 6 in the database) the page is going to error out. My quick fix is just subtracting 1 from the value of whatever DateTime.now().weekday returns so it aligns with the database. Now the page doesn't error out and should display the correct hours according to the appropriate day. 