### PR TITLE
Fix restaurants test

### DIFF
--- a/lib/restaurants.dart
+++ b/lib/restaurants.dart
@@ -252,7 +252,7 @@ class _RestaurantsPageState extends State<RestaurantsPage> {
 
   /// Render the rating widgets.
   Widget buildRatingView(BuildContext context) {
-    var stars = List<IconButton>.generate(5, (i) {
+    var stars = List<IconButton>.generate(3, (i) {
       return IconButton(
         icon: Icon(rating > i ? Icons.star : Icons.star_border),
         onPressed: () => setState(() => rating = (i+1)),


### PR DESCRIPTION
Five stars causes an overflow, so reduce it to three. Maybe look
into this more later.