### PR TITLE
Tweak restaurant list page to fix integration tests

### DIFF
--- a/lib/restaurant_list.dart
+++ b/lib/restaurant_list.dart
@@ -18,7 +18,6 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
   @override
   Widget build(BuildContext context) {
     var restaurants = widget.store.collection("restaurants");
-    var docSnap = restaurants.doc().snapshots();
 
     return Scaffold(
       appBar: JustEatItAppBar.create(context, widget.auth),
@@ -29,7 +28,7 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
           Container(
             alignment: Alignment.center,
             color: Colors.green.shade50,
-            height: 100,
+            height: 80,
             width: MediaQuery.of(context).size.width,
             child: Text("Restaurant List",
               style: TextStyle(
@@ -40,31 +39,33 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
             ),
           ),
           Expanded(
-            child: StreamBuilder<QuerySnapshot>(
-              stream: widget.store.collection('restaurants').snapshots(),
-              builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
-                if (!snapshot.hasData) return const Text('Loading...');
-                final int messageCount = snapshot.data!.docs.length;
-                return ListView.builder(
-                  itemCount: messageCount,
-                  itemBuilder: (_, int index) {
-                    final DocumentSnapshot data = snapshot.data!.docs[index];
-                    return ListTile(
-                      title: Text(
-                        '${data['name']} (${data['location']})',
-                        style: TextStyle(
-                          fontSize: 20,
-                          color: Colors.green.shade900,
+            child: FractionallySizedBox(
+              widthFactor: 0.8,
+              child: StreamBuilder<QuerySnapshot>(
+                stream: restaurants.snapshots(),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) return const Text('Loading...');
+                  return ListView.builder(
+                    itemCount: snapshot.data!.docs.length,
+                    itemBuilder: (_, index) {
+                      final data = snapshot.data!.docs[index];
+                      return ListTile(
+                        title: Text(
+                          '${data['name']} (${data['location']})',
+                          style: TextStyle(
+                            fontSize: 20,
+                            color: Colors.green.shade900,
+                          ),
                         ),
-                      ),
-                      subtitle: Text(
-                        data['description'],
-                        textAlign: TextAlign.justify,
-                      ),
-                    );
-                  },
-                );
-              },
+                        subtitle: Text(
+                          data['description'],
+                          textAlign: TextAlign.justify,
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ),
           Container(

--- a/lib/restaurant_list.dart
+++ b/lib/restaurant_list.dart
@@ -23,7 +23,6 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
     return Scaffold(
       appBar: JustEatItAppBar.create(context, widget.auth),
       //body of list view
-        //created a custom scrolling list with adjustable length
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -41,52 +40,37 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
             ),
           ),
           Expanded(
-          //width: 1000,
-            child: CustomScrollView(
-              slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (context, int index) {
-                      return Container(
-                        alignment: Alignment.center,
-                        //color: Colors.yellow.shade700,
-                        height: 150,
-                        child: FutureBuilder<DocumentSnapshot>(
-                          future: restaurants.doc(index.toString()).get(),
-                          builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
-                            if(snapshot.hasError){
-                              return const Text("Something went wrong");
-                            }
-
-                            if(snapshot.hasData && !snapshot.data!.exists){
-                              return const Text("Document does not exist",);
-                            }
-
-                            if(snapshot.connectionState == ConnectionState.done) {
-                              Map<String, dynamic> data = snapshot.data!.data() as Map<String, dynamic>;
-                              return Text(
-                                "${data["name"]} - ${data["location"]}", 
-                                style: TextStyle(
-                                  fontSize: 30, 
-                                  color: Colors.green.shade900,
-                                ),
-                              );
-                            }
-                            return const Text("loading"); //appears while firestore is retrieving data
-                          },
+            child: StreamBuilder<QuerySnapshot>(
+              stream: widget.store.collection('restaurants').snapshots(),
+              builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+                if (!snapshot.hasData) return const Text('Loading...');
+                final int messageCount = snapshot.data!.docs.length;
+                return ListView.builder(
+                  itemCount: messageCount,
+                  itemBuilder: (_, int index) {
+                    final DocumentSnapshot data = snapshot.data!.docs[index];
+                    return ListTile(
+                      title: Text(
+                        '${data['name']} (${data['location']})',
+                        style: TextStyle(
+                          fontSize: 20,
+                          color: Colors.green.shade900,
                         ),
-                      );
-                    },
-                  childCount: 25, //adjusts the current length of the list
-                  )
-                )
-              ],
+                      ),
+                      subtitle: Text(
+                        data['description'],
+                        textAlign: TextAlign.justify,
+                      ),
+                    );
+                  },
+                );
+              },
             ),
           ),
           Container(
             alignment: Alignment.center,
             color: Colors.green.shade50,
-            height: 100,
+            height: 75,
             width: MediaQuery.of(context).size.width,
             child: ElevatedButton(
               child: const Text(
@@ -98,7 +82,7 @@ class _RestaurantListPageState extends State<RestaurantListPage> {
             ),
           ),
         ],
-      ),     
+      ),
     );
-  } 
+  }
 } // RESTAURANTLISTPAGE CLASS END

--- a/test/restaurant_list_test.dart
+++ b/test/restaurant_list_test.dart
@@ -12,6 +12,7 @@ import 'package:justeatit/signup.dart';
 import 'package:justeatit/restaurants.dart';
 
 import 'helpers.dart';
+import 'recommend_unit_test.dart';
 
 class RestaurantListPageWrapper extends StatelessWidget {
   final FirebaseAuth auth;
@@ -58,14 +59,12 @@ void main() {
       mockUser: MockUser()
     );
     await tester.pumpWidget(RestaurantListPageWrapper(auth: auth, store: store));
-    await tester.tap(find.widgetWithText(ElevatedButton, "Get Recommendation"));
-    await tester.pump();
-    //expect(find.textContaining('Go!'), findsWidgets);
+    await tester.tap(find.text("Get Recommendation"));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Go!'), findsWidgets);
     expect(find.byType(ElevatedButton), findsWidgets);
-
   });
 
-  /* CAN'T SEEM TO GET THIS ONE...
   testWidgets('Restaurant names are correctly displayed', (tester) async {
     setDisplayDimensions(tester);
     final store = FakeFirebaseFirestore();
@@ -76,8 +75,8 @@ void main() {
     await tester.pumpWidget(RestaurantListPageWrapper(auth: auth, store: store));
     await addRestaurant(store, chipotle);
     await tester.pumpAndSettle(const Duration(milliseconds: 100));
-    expect(find.text("Chipotle - Johnson Center"), findsWidgets);
-    //expect(find.byType(SliverList), findsWidgets); //look for a sliverlist
-    //expect(find.widgetWithText(SliverList, "Chipotle - Johnson Center"), findsOneWidget);
-  });*/
+    expect(find.textContaining(chipotle['name']!.toString()), findsWidgets);
+    expect(find.textContaining(chipotle['location']!.toString()), findsWidgets);
+    expect(find.text(chipotle['description']!.toString()), findsWidgets);
+  });
 }


### PR DESCRIPTION
There might be a bug in the `SliverList` which keeps it from working in Firebase testing, I'm not sure, but anyway I used another approach (from https://firebase.flutter.dev/docs/testing/testing/) and it worked. It loads everything at once instead of on demand, but since we have only 25 restaurants, it's not a problem.

@jen-mo I also tweaked the data shown and the format a bit... what do you think?

![image](https://user-images.githubusercontent.com/31262113/166125459-84556ef0-9fa2-4746-92db-ce9b82d5a6ab.png)

![image](https://user-images.githubusercontent.com/31262113/166125432-d979ed8f-21e1-44dd-a14f-3d4dd635d702.png)
